### PR TITLE
jqt.autotitles.js - The change prevents hardcoded titles from being overwritten by the extension.

### DIFF
--- a/extensions/jqt.autotitles.js
+++ b/extensions/jqt.autotitles.js
@@ -31,7 +31,7 @@
                     if (data.direction === 'in'){
                         var $title = $(titleSelector, $(e.target));
                         var $ref = $(e.target).data('referrer');
-                        if ($title.length && $ref){
+                        if ($title.length && $ref && $title.html() === ''){
                             $title.html($ref.text());
                         }
                     }


### PR DESCRIPTION
This was my first commit to the DZ/jQT fork. At that time I didn't know how to send pull requests, so here it is. It's a simple change and doesn't affect anything else.

Thanks,
djp
