### PR TITLE
Small fix for goTo without animation

### DIFF
--- a/jqtouch/jqtouch.js
+++ b/jqtouch/jqtouch.js
@@ -363,7 +363,8 @@
             $(':focus').blur();
 
             // Make sure we are scrolled up to hide location bar
-            toPage.css('top', window.pageYOffset);
+            if (animation)
+                toPage.css('top', window.pageYOffset);
 
             // Define callback to run after animation completes
             var callback = function animationEnd(event) {


### PR DESCRIPTION
If you »jump« between a (long) scrolled page  and a second page, they wouldn't start at the top and over each page is a »gap«. The css top property won't be reset to 0, if there is no animation, so it shoudn't be set. 

I'll hope, that my short description help you. and please excuse my bad english.

Best regards
dom
