### PR TITLE
don't allow taps in the middle of a request

### DIFF
--- a/jqtouch/jqtouch.js
+++ b/jqtouch/jqtouch.js
@@ -666,7 +666,9 @@
             $el.bind('touchmove', touchmove).bind('touchend', touchend).bind('touchcancel', touchcancel);
 
             hoverTimeout = setTimeout(function() {
-                $el.makeActive();
+                if (tapReady) {
+                    $el.makeActive();
+                }
             }, jQTSettings.hoverDelay);
 
             pressTimeout = setTimeout(function() {


### PR DESCRIPTION
These changes set tapReady to false in showPageByHref so that tap events are ignored in the middle of a pending ajax request.
