### PR TITLE
submitForm() bugfix for formSelector

### DIFF
--- a/jqtouch/jqtouch.js
+++ b/jqtouch/jqtouch.js
@@ -462,15 +462,16 @@
             var $form = (typeof(e)==='string') ? $(e).eq(0) : (e.target ? $(e.target) : $(e));
             
             _debug($form.attr('action'));
-            
-            if ($form.length && $form.is(jQTSettings.formSelector) && $form.attr('action')) {
+            if (!$form.length) return false;
+            // someone else will handle this event
+            if (!$form.is(jQTSettings.formSelector)) return true;
+            if ($form.attr('action')) {
                 showPageByHref($form.attr('action'), {
                     data: $form.serialize(),
                     method: $form.attr('method') || "POST",
                     animation: animations[0] || null,
                     callback: callback
                 });
-                return false;
             }
             return false;
         }


### PR DESCRIPTION
submitForm() was not correctly dealing with a user-specified formSelector.  submitForm() needs to return true when the form does not match formSelector, since the user may have their own live handler for the event.  (Live handler would require event to bubble up, so submitForm() needs to return true in that case)
