### PR TITLE
3 bug fixes

### DIFF
--- a/jqtouch/jqtouch.js
+++ b/jqtouch/jqtouch.js
@@ -192,11 +192,11 @@
 
                 if ($.support.animationEvents && animation && jQTSettings.useAnimations) {
                     fromPage.unbind('webkitAnimationEnd', navigationEndHandler);
-                    fromPage.attr('class', '');
-                    toPage.attr('class', 'current');
+                    fromPage.removeClass('out current ' + finalAnimationName);
+                    toPage.removeClass('in ' + finalAnimationName);
                     // toPage.css('top', 0);
                 } else {
-                    fromPage.attr('class', '');
+                    fromPage.removeClass('current');
                 }
 
                 // Housekeeping


### PR DESCRIPTION
Hi, I've included 3 bug fixes in this request:

o in navigationEndHandler(), don't clobber class attribute of page div element;
  instead, selectively remove 'in', 'out', and 'current'.

o submitForm() was not correctly dealing with a user-specified formSelector. submitForm() needs to return true when the form does not match formSelector, since the user may have their own live handler for the event. (Live handler would require event to bubble up, so submitForm() needs to return true in that case)

o set tapReady to false in showPageByHref so that tap events are ignored in the middle of a pending ajax request.
