### PR TITLE
Reloading ajax loaded pages will result in duplicate pages in the DOM

### DIFF
--- a/jqtouch/jqtouch.js
+++ b/jqtouch/jqtouch.js
@@ -354,6 +354,9 @@
                     $node.attr('id', 'page-' + (++newPageCount));
                 }
 
+		        /* remove any existing instance */
+		        $('#' + $node.attr('id')).remove();
+
 		        $body.trigger('pageInserted', {page: $node.appendTo($body)});
 
                 if ($node.hasClass('current') || !targetPage) {


### PR DESCRIPTION
When you re-load ajax loaded pages you will get several divs with the same id. This sometimes leads to unexpected pages being displayed and the DOM will grow as you navigate the application back and forth resulting in bad performance. This behavior is only visible when cacheGetRequests is set to false.

My fix makes sure that when ajax-loading pages any existing pages with the same id's will be removed first.
