### PR TITLE
Fix bug in Firefox

### DIFF
--- a/jqtouch/jqtouch.js
+++ b/jqtouch/jqtouch.js
@@ -293,17 +293,6 @@
                 _debug('The reverse parameter was sent to goTo() function, which is bad.', true);
             }
 
-            if (!tapReady) {
-                _debug('Enqueueing navigation to ' + toPage);
-                navigationQueue.push({
-                    toPage: toPage,
-                    animation: animation
-                });
-
-                // Wait until the current animation finishes and navigationEndHandler runs before proceeding
-                return;
-            }
-
             var fromPage = hist[0].page;
 
             if (typeof animation === 'string') {


### PR DESCRIPTION
Hi guys, I'm a huge fan of your work.  These two commits fix a bug in jQTouch that has made it unusable in Firefox -- jQT tried to log even if window.console is undefined, e.g. in Firefox when Firebug is closed.  The exception thrown aborts jQT's initialization and makes the web app unusable on Firefox.  After my changes, jQT won't try log unless window.console is defined.
