### PR TITLE
make "now" local in _debug

### DIFF
--- a/jqtouch/jqtouch.js
+++ b/jqtouch/jqtouch.js
@@ -89,7 +89,7 @@
 
         function _debug(message) {
             var now = (new Date).getTime();
-            delta = now - lastTime;
+            var delta = now - lastTime;
             lastTime = now;
             if (jQTSettings.debug) {
                 if (message) {


### PR DESCRIPTION
Hi,

i noticed a problem by working with jQTouch and nowjs. The _debug method overrides the global "now" variable. 
This pull request should fix this. 
