### PR TITLE
Attempt at fixing #278; 2d animation fallbacks

### DIFF
--- a/jqtouch/jqtouch.js
+++ b/jqtouch/jqtouch.js
@@ -186,27 +186,29 @@
 
                 tapReady = false;
 
+                var initialAnimationName = animation.name;
+
                 // Fail over to 2d animation if need be
                 if (!$.support.transform3d && animation.is3d) {
-                    animation.name = jQTSettings.fallback2dAnimation;
+                    initialAnimationName = jQTSettings.fallback2dAnimation;
                 }
 
                 // Reverse animation if need be
                 var finalAnimationName;
                 if (goingBack) {
-                    if (animation.name.indexOf('left') > 0) {
-                        finalAnimationName = animation.name.replace(/left/, 'right');
-                    } else if (animation.name.indexOf('right') > 0) {
-                        finalAnimationName = animation.name.replace(/right/, 'left');
-                    } else if (animation.name.indexOf('up') > 0) {
-                        finalAnimationName = animation.name.replace(/up/, 'down');
-                    } else if (animation.name.indexOf('down') > 0) {
-                        finalAnimationName = animation.name.replace(/down/, 'up');
+                    if (initialAnimationName.indexOf('left') > 0) {
+                        finalAnimationName = initialAnimationName.replace(/left/, 'right');
+                    } else if (initialAnimationName.indexOf('right') > 0) {
+                        finalAnimationName = initialAnimationName.replace(/right/, 'left');
+                    } else if (initialAnimationName.indexOf('up') > 0) {
+                        finalAnimationName = initialAnimationName.replace(/up/, 'down');
+                    } else if (initialAnimationName.indexOf('down') > 0) {
+                        finalAnimationName = initialAnimationName.replace(/down/, 'up');
                     } else {
-                        finalAnimationName = animation.name;
+                        finalAnimationName = initialAnimationName;
                     }
                 } else {
-                    finalAnimationName = animation.name;
+                    finalAnimationName = initialAnimationName;
                 }
 
                 // _debug('finalAnimationName is ' + finalAnimationName);


### PR DESCRIPTION
As mentioned in #278, the animation fallback mechanism actually changes the names of the animation objects rather than changing a reference to them - creating all sorts of havoc on non-3D capable devices.

This patch is a simple attempt at fixing the issue; rather than updating the name of the animation itself, it simply uses a variable `initialAnimationName` and from there on follows normal processing in order to end up at `finalAnimationName`.

The code has been tested on Android so far, iOS devices are soon to follow. Any feedback from the community is also welcome and appreciated. :)
