### PR TITLE
Fix iOS viewport "tip" due to errant semicolon

### DIFF
--- a/jqtouch/jqtouch.js
+++ b/jqtouch/jqtouch.js
@@ -368,7 +368,7 @@
 
             // Set viewport
             if (jQTSettings.fixedViewport) {
-                hairExtensions += '<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0;"/>';
+                hairExtensions += '<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/>';
             }
 
             // Set full-screen


### PR DESCRIPTION
Remove the semicolon and you've got a valid viewport...
