### PR TITLE
jQuery Demo missing jQTouch Library

### DIFF
--- a/demos/main/index.html
+++ b/demos/main/index.html
@@ -7,8 +7,9 @@
 
         <script src="../../src/lib/zepto.js" type="text/javascript" charset="utf-8"></script>
         <script src="../../src/jqtouch.js" type="text/javascript" charset="utf-8"></script>
-        <!-- Uncomment the following two lines (and comment out the previous two) to use jQuery instead of Zepto. -->
+        <!-- Uncomment the following three lines (and comment out the previous two) to use jQuery instead of Zepto. -->
         <!-- <script src="../../src/lib/jquery-1.7.min.js" type="application/x-javascript" charset="utf-8"></script> -->
+        <!-- <script src="../../src/jqtouch.js" type="text/javascript" charset="utf-8"></script> -->
         <!-- <script src="../../src/jqtouch-jquery.js" type="application/x-javascript" charset="utf-8"></script> -->
 
         <script src="../../extensions/jqt.themeswitcher.js" type="application/x-javascript" charset="utf-8"></script>


### PR DESCRIPTION
Issue #401

When editing demos/main/index.html to use the jQuery version this throws an exception. Turns out the actual library needs to be included as well as the jQuery Linker.
