### PR TITLE
Fix animation array name corruption.

### DIFF
--- a/src/jqtouch.js
+++ b/src/jqtouch.js
@@ -147,16 +147,17 @@
             toPage.trigger('pageAnimationStart', { direction: 'in', back: goingBack });
 
             if ($.support.animationEvents && animation && jQTSettings.useAnimations) {
-                // Fail over to 2d animation if need be
-                if (!$.support.transform3d && animation.is3d) {
-                    warn('Did not detect support for 3d animations, falling back to ' + jQTSettings.defaultAnimation);
-                    animation.name = jQTSettings.defaultAnimation;
-                }
-
-                // Reverse animation if need be
                 var finalAnimationName = animation.name,
                     is3d = animation.is3d ? 'animating3d' : '';
 
+                // Fail over to 2d animation if need be
+                if (!$.support.transform3d && animation.is3d) {
+                    warn('Did not detect support for 3d animations, falling back to ' + jQTSettings.defaultAnimation);
+                    finalAnimationName = jQTSettings.defaultAnimation;
+                    is3d = '';
+                }
+
+                // Reverse animation if need be
                 if (goingBack) {
                     finalAnimationName = finalAnimationName.replace(/left|right|up|down|in|out/, reverseAnimation );
                 }


### PR DESCRIPTION
If a 3d animation was attempted on a platform that did not support it,
the animation.name property of the attempted 3d animation was set to
the default animation name.  This caused subsequent animations to
fail.

<!---
@huboard:{"order":406.0}
-->
