### PR TITLE
fallback for non-3d browsers bug fix

### DIFF
--- a/src/jqtouch.js
+++ b/src/jqtouch.js
@@ -147,15 +147,15 @@
             toPage.trigger('pageAnimationStart', { direction: 'in', back: goingBack });
 
             if ($.support.animationEvents && animation && jQTSettings.useAnimations) {
-                // Fail over to 2d animation if need be
-                if (!$.support.transform3d && animation.is3d) {
-                    warn('Did not detect support for 3d animations, falling back to ' + jQTSettings.defaultAnimation);
-                    animation.name = jQTSettings.defaultAnimation;
-                }
-
                 // Reverse animation if need be
                 var finalAnimationName = animation.name,
                     is3d = animation.is3d ? 'animating3d' : '';
+                    
+                // Fail over to 2d animation if need be
+                if (!$.support.transform3d && animation.is3d) {
+                    warn('Did not detect support for 3d animations, falling back to ' + jQTSettings.defaultAnimation);
+                    finalAnimationName = jQTSettings.defaultAnimation;
+                }
 
                 if (goingBack) {
                     finalAnimationName = finalAnimationName.replace(/left|right|up|down|in|out/, reverseAnimation );


### PR DESCRIPTION
When using a non-3d browser, if you call same effect twice it will cause 'undefined in current' class error and jQTouch stops working.

This is because on `.goTo()` function you pass `animation = animations[i]` as reference of the animation array.

The problem is that on `.doNavigation()` you replace the `animation.name` with default animation, in order to fallback, but this replaces the name of the original array, causing jQTouch to stop working on a second call (because `animation.name` is undefined since `animation` is a string).

To fix this I just reverted the order in which you define `finalAnimationName` variable and then I check if the browser supports 3d, but this time changing this local variable instead of animation.name.

Here, using Chrome over Ubuntu (without WebGL due to VMWare 3d software rendering).
